### PR TITLE
Fix demo response handling for CI build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,12 +44,17 @@ int main() {
     c.publish("demo.hello",  buf.data(), buf.size());
 
 
-  int rsid = c.respond("service.greeting",
+  int rsid = c.respond(
+    "service.greeting",
     [](const std::string&, const std::string& data) -> std::string {
-      std::string req;
-      resp = "Hello " + req;
+      demo::Message req_msg;
+      if (!req_msg.ParseFromString(data)) {
+        return {};
+      }
+      demo::Message resp_msg;
+      resp_msg.set_content("Hello " + req_msg.content());
       std::string buf;
-      resp.SerializeToString(&buf);
+      resp_msg.SerializeToString(&buf);
       return buf;
     });
 


### PR DESCRIPTION
### Motivation
- The demo target failed to compile due to an invalid response lambda that referenced undefined variables and did not parse incoming protobuf data, breaking CI/demo build.

### Description
- Updated `src/main.cpp` to fix the `c.respond("service.greeting", ...)` handler so it parses the incoming `demo::Message` with `ParseFromString` and constructs a `demo::Message` response.
- Replaced the previous undefined/incorrect variables with `req_msg` and `resp_msg` and call `resp_msg.SerializeToString(&buf)` to produce the reply payload.
- Reformatted the `respond` call to a multi-line lambda for clarity.
- Changes are confined to `src/main.cpp` and aim to make the demo compile when protobuf is available.

### Testing
- Attempted to configure the build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`, but configuration failed because Protobuf was not found (`Could NOT find Protobuf`), so no automated tests were executed.
- No unit tests or CI runs completed in this environment due to the missing protobuf compiler/library.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b9347d10832b945c8e345b666d15)